### PR TITLE
Add Example input to promptbot

### DIFF
--- a/docs/prompt.md
+++ b/docs/prompt.md
@@ -55,10 +55,10 @@ A class for generating a prompt and retrieving a response from GPT OpenAI.
 - `get_prompt(self)`
     Creates the prompt for the OpenAI API.
     
-- `set_and_return_improve_prompt(self)`
+- `_set_and_return_improve_prompt(self)`
     Creates the prompt for improving the previous output.
     
-- `set_improve(self, improve)`
+- `_set_improve(self, improve)`
     Sets the improvement made between two different versions.
     
 - `run_ai(self, improve=False)`
@@ -67,7 +67,7 @@ A class for generating a prompt and retrieving a response from GPT OpenAI.
 - `start_improvements(self)`
     Starts the improvement process.
     
-- `execute_code(self)`
+- `_execute_code(self)`
     Executes the output if `execute_output` is `True`.
     
 - `save_to_file(self, file_name)`
@@ -112,12 +112,22 @@ Adds a rule to the list of `PromptBot` rules.
 - `self`
 
 
-## set_example_output(self, output)
-Sets the example output.
+## set_example_output(self, output_data)
+Sets the example output that the AI will try to achieve.
 
 ### Parameters
-- `output`: `str`
+- `output_data`: `str`
     the example output to be set
+    
+### Returns
+- `self`
+
+## set_example_input(self, input_data)
+Sets the example input that AI will use to understand the data it will receive.
+
+### Parameters
+- `input_data`: `str`
+    the example input to be set
     
 ### Returns
 - `self`
@@ -142,7 +152,7 @@ Creates the prompt for the OpenAI API.
     the prompt for the OpenAI API
 
 
-## set_and_return_improve_prompt(self)
+## _set_and_return_improve_prompt(self)
 Creates the prompt for improving the previous output.
 
 ### Returns
@@ -150,7 +160,7 @@ Creates the prompt for improving the previous output.
     the prompt for improving the previous output
 
 
-## set_improve(self, improve)
+## _set_improve(self, improve)
 Sets the improvement made between two different versions.
 
 ### Parameters
@@ -177,7 +187,7 @@ Runs OpenAI API on the prompt and retrieves the result.
 Starts the improvement process.
 
 
-## execute_code(self)
+## _execute_code(self)
 Executes the output if `execute_output` is `True`.
 
 

--- a/examples/document_bot.py
+++ b/examples/document_bot.py
@@ -9,8 +9,8 @@ def main():
         .add_rule("The output must be in valid markdown format.")
         .add_rule("I cannot change code in any way")
         .add_rule("I cannot provide any dialog or request additional info")
-        .set_example_output("""# Function Name \nHere is a brief description of my python code. In this section, 
-        I will describe the overall purpose of my code and its main functionalities. \n\n## Function 1\nThis function 
+        .set_example_output("""# Function Name \nHere is a brief description of the python code. In this section, 
+        we will describe the overall purpose of the code and its main functionalities. \n\n## Function 1\nThis function 
         does X, Y, and Z. Here is how it works: \n\n```python\n def function1(param1, param2):\n    # code block\n 
         ```\n\n## Function 2\nThis function does A, B, and C. Here is how it works: \n\n```python\n def function2(
         param1, param2):\n    # code block\n ```""")

--- a/examples/tag_bot.py
+++ b/examples/tag_bot.py
@@ -1,0 +1,82 @@
+from promptbot import PromptBot
+
+
+class TagBot(PromptBot):
+    def __init__(self):
+        super().__init__("TagBot")
+        self.add_cmd("I create creative tags for products based on text descriptions.")
+        self.add_cmd("I am an expert at linguistics and can easily ensure meaning is conveyed at tag creation.")
+        self.add_rule("I must output only in valid CSV format")
+        self.add_rule("I cannot provide any dialog or request additional info")
+        self.add_rule("I must not change the product ID")
+        self.set_example_input('{"id":"B04", "text":"Glittered Hammock Shirt with stylish buttons"}\n')
+        self.set_example_output('123|Glittered Hammock Shirt with stylish buttons|shirt, glitter, stylish')
+
+    @staticmethod
+    def yield_batches(list_of_products, batch_size=10):
+        for i in range(0, len(list_of_products), batch_size):
+            yield list_of_products[i:i + batch_size]
+
+    def run(self, list_of_products):
+        results = []
+        for batch in self.yield_batches(list_of_products, batch_size=10):
+            print("Processing batch of " + str(len(batch)) + " tag requests")
+            self.set_goal(f"GENERATE TAGS FOR:\n{batch}")
+            result = self.run_ai()
+            results.append(result)
+
+        return results
+
+
+if __name__ == "__main__":
+    bot = TagBot()
+    product_list = [
+        {"id": "B001",
+         "text": "Road Bike - A lightweight bike designed for speed on paved roads, with narrow tires and drop "
+                 "handlebars."},
+        {"id": "B002",
+         "text": "Mountain Bike - A sturdy bike built for off-road terrain, with wide tires and suspension for shock "
+                 "absorption."},
+        {"id": "B003",
+         "text": "Hybrid Bike - A versatile bike that combines features of road and mountain bikes, ideal for urban "
+                 "commuting and light trail riding."},
+        {"id": "B004",
+         "text": "Folding Bike - A compact bike that can be folded and stored easily, perfect for city dwellers with "
+                 "limited storage space."},
+        {"id": "B005",
+         "text": "Cruiser Bike - A comfortable bike with a relaxed, upright riding position and wide, cushioned seat, "
+                 "ideal for leisurely rides."},
+        {"id": "B006",
+         "text": "Electric Bike - A bike with an electric motor and battery, offering pedal assistance or full electric"
+                 " power, ideal for longer commutes or hilly terrain."},
+        {"id": "B007",
+         "text": "BMX Bike - A small, lightweight bike with a strong frame and large handlebars, ideal for performing "
+                 "tricks and stunts."},
+        {"id": "B008",
+         "text": "Touring Bike - A bike designed for long-distance travel, with a comfortable riding position, durable "
+                 "frame, and racks for carrying gear."},
+        {"id": "B009",
+         "text": "Gravel Bike - A versatile bike designed for riding on mixed terrain, with wider tires and a more "
+                 "relaxed riding position than a road bike."},
+        {"id": "B010",
+         "text": "Tandem Bike - A bike designed for two riders, with two sets of pedals and a longer frame, ideal for "
+                 "couples or friends who want to ride together."}
+    ]
+
+    bot.run(product_list)
+    print(bot.result)
+    bot.start_improvements()
+    with open("tags_result.csv", "w") as f:
+        f.write(bot.result)
+
+# Example output:
+# B001|Road Bike - A lightweight bike designed for speed on paved roads, with narrow tires and drop handlebars.|road bike, lightweight, speed, paved, narrow, drop handlebars
+# B002|Mountain Bike - A sturdy bike built for off-road terrain, with wide tires and suspension for shock absorption.|mountain bike, sturdy, off-road, wide tires, suspension, shock absorption
+# B003|Hybrid Bike - A versatile bike that combines features of road and mountain bikes, ideal for urban commuting and light trail riding.|hybrid bike, versatile, road bike, mountain bike, urban commuting, light trail riding
+# B004|Folding Bike - A compact bike that can be folded and stored easily, perfect for city dwellers with limited storage space.|folding bike, compact, stored easily, city dwellers, limited storage space
+# B005|Cruiser Bike - A comfortable bike with a relaxed, upright riding position and wide, cushioned seat, ideal for leisurely rides.|cruiser bike, comfortable, relaxed riding position, wide cushioned seat, leisurely rides
+# B006|Electric Bike - A bike with an electric motor and battery, offering pedal assistance or full electric power, ideal for longer commutes or hilly terrain.|electric bike, electric motor, battery, pedal assistance, full electric power, longer commutes, hilly terrain
+# B007|BMX Bike - A small, lightweight bike with a strong frame and large handlebars, ideal for performing tricks and stunts.|BMX bike, small, lightweight, strong frame, large handlebars, performing tricks, stunts
+# B008|Touring Bike - A bike designed for long-distance travel, with a comfortable riding position, durable frame, and racks for carrying gear.|touring bike, long-distance travel, comfortable riding position, durable frame, racks, carrying gear
+# B009|Gravel Bike - A versatile bike designed for riding on mixed terrain, with wider tires and a more relaxed riding position than a road bike.|gravel bike, versatile, mixed terrain, wider tires, relaxed riding position, road bike
+# B010|Tandem Bike - A bike designed for two riders, with two sets of pedals and a longer frame, ideal for couples or friends who want to ride together.|tandem bike, two riders, two sets of pedals, longer frame, couples, friends, ride together


### PR DESCRIPTION
* add set_example_input to PromptBot class
* refactored the prompt assembly to cater for when rules, commands and examples have not been set
* refactored class to have all proposed private access methods at the bottom of the definition
* added tagbot example to illustrate the use of set_example_input
* updated readme